### PR TITLE
Improve bot stability and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+*.log
+.gradle/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ccxt
+pandas
+numpy

--- a/trading_bot/README.md
+++ b/trading_bot/README.md
@@ -1,0 +1,33 @@
+# Trading Bot
+
+Este directorio contiene un ejemplo básico de un bot de trading para criptomonedas.
+
+**Advertencia**: Operar con criptomonedas y especialmente con futuros y apalancamiento
+implica riesgos elevados. Existe la posibilidad de perder la totalidad del capital
+invertido. Utilice este software únicamente con fines educativos y bajo su propia
+responsabilidad.
+
+## Instalación
+
+1. Cree un entorno virtual de Python.
+2. Instale las dependencias requeridas (`ccxt` y `pandas` son necesarias para
+   la ejecución):
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Edite `bot.py` con sus claves de API y ejecute:
+
+```bash
+python -m trading_bot.bot
+```
+
+El ejemplo implementa:
+- Análisis técnico sencillo con EMA y RSI.
+- Gestión de riesgo básica mediante porcentaje de capital.
+- Ejecución asincrónica de operaciones.
+
+Amplíe las funciones según sus necesidades antes de operar en cuentas reales.

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -1,0 +1,4 @@
+"""Módulo de ejemplo de bot de trading."""
+
+# El contenido se organiza en submódulos para evitar dependencias innecesarias
+# durante la importación del paquete.

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -1,0 +1,60 @@
+import asyncio
+from importlib import import_module
+import pandas as pd
+from .strategy import Strategy
+from .risk_management import RiskManager
+
+try:
+    ccxt = import_module('ccxt.async_support')
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "ccxt is required to run the trading bot. Please install it via 'pip install ccxt'."
+    ) from e
+
+
+class TradingBot:
+    """Ejemplo básico de bot de trading asincrónico."""
+
+    def __init__(self, exchange_id='binance', api_key=None, secret=None,
+                 symbol='BTC/USDT', timeframe='1h'):
+        if not hasattr(ccxt, exchange_id):
+            raise ValueError(f"Exchange '{exchange_id}' not supported by ccxt")
+
+        self.exchange = getattr(ccxt, exchange_id)({
+            'apiKey': api_key,
+            'secret': secret,
+            'enableRateLimit': True
+        })
+        self.symbol = symbol
+        self.timeframe = timeframe
+        self.strategy = Strategy()
+        self.risk_manager = RiskManager()
+
+    async def fetch_ohlcv(self):
+        ohlcv = await self.exchange.fetch_ohlcv(self.symbol, timeframe=self.timeframe, limit=500)
+        df = pd.DataFrame(ohlcv, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
+        df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
+        return df
+
+    async def trade(self):
+        df = await self.fetch_ohlcv()
+        signal = self.strategy.generate_signal(df)
+        position_size = self.risk_manager.calculate_position_size(df['close'].iloc[-1])
+        print(f'Signal: {signal}, size: {position_size}')
+        # Aquí debería enviarse la orden al exchange según la señal
+
+    async def run(self):
+        while True:
+            try:
+                await self.trade()
+            except Exception as e:
+                print(f'Error: {e}')
+            await asyncio.sleep(60)
+
+    async def close(self):
+        await self.exchange.close()
+
+
+if __name__ == '__main__':
+    bot = TradingBot()
+    asyncio.run(bot.run())

--- a/trading_bot/risk_management.py
+++ b/trading_bot/risk_management.py
@@ -1,0 +1,17 @@
+class RiskManager:
+    """Funciones básicas de gestión de riesgo."""
+
+    def __init__(self, balance=1000, risk_per_trade=0.01, stop_loss_pct=0.02):
+        self.balance = balance
+        self.risk_per_trade = risk_per_trade
+        self.stop_loss_pct = stop_loss_pct
+
+    def calculate_position_size(self, price: float) -> float:
+        if price <= 0:
+            raise ValueError("Price must be positive")
+
+        risk_amount = self.balance * self.risk_per_trade
+        stop_loss_amount = price * self.stop_loss_pct
+        if stop_loss_amount <= 0:
+            return 0.0
+        return risk_amount / stop_loss_amount

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+
+def _ema(series: pd.Series, span: int) -> pd.Series:
+    """Simple exponential moving average without external deps."""
+    return series.ewm(span=span, adjust=False).mean()
+
+
+def _rsi(series: pd.Series, period: int) -> pd.Series:
+    """Relative Strength Index implementation."""
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=period).mean()
+    avg_loss = loss.rolling(window=period).mean()
+    rs = avg_gain / avg_loss.replace(0, pd.NA)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi.fillna(50)
+
+
+class Strategy:
+    """Implementación sencilla utilizando EMA y RSI."""
+
+    def __init__(self, ema_short=9, ema_long=21, rsi_period=14):
+        self.ema_short = ema_short
+        self.ema_long = ema_long
+        self.rsi_period = rsi_period
+
+    def generate_signal(self, df: pd.DataFrame) -> str:
+        data = df.copy()
+        data['ema_short'] = _ema(data['close'], span=self.ema_short)
+        data['ema_long'] = _ema(data['close'], span=self.ema_long)
+        data['rsi'] = _rsi(data['close'], period=self.rsi_period)
+
+        if data['ema_short'].iloc[-1] > data['ema_long'].iloc[-1] and data['rsi'].iloc[-1] < 70:
+            return 'buy'
+        if data['ema_short'].iloc[-1] < data['ema_long'].iloc[-1] and data['rsi'].iloc[-1] > 30:
+            return 'sell'
+        return 'hold'

--- a/trading_bot/tests/test_risk_management.py
+++ b/trading_bot/tests/test_risk_management.py
@@ -1,0 +1,13 @@
+import pytest
+from trading_bot.risk_management import RiskManager
+
+def test_position_size():
+    rm = RiskManager(balance=1000, risk_per_trade=0.02, stop_loss_pct=0.02)
+    size = rm.calculate_position_size(100)
+    assert size == 10
+
+
+def test_invalid_price():
+    rm = RiskManager()
+    with pytest.raises(ValueError):
+        rm.calculate_position_size(0)


### PR DESCRIPTION
## Summary
- update trading bot to check for ccxt dependency
- implement simple EMA and RSI without `ta`
- guard against invalid prices in risk management
- expand unit tests
- document dependencies and ignore Gradle cache

## Testing
- `PYTHONPATH=. pytest -q`
- `gradle test` *(fails: Could not resolve dependencies)*
- `pip install -r requirements.txt` *(fails: Could not find a version due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685aedda80788333b7d621dd5cc2cabf